### PR TITLE
Add raw MIDI capture and file replay for debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `record` options `--raw-capture`, `--replay`, and `--replay-realtime`: write a Type 1 debug MIDI of the live input stream and replay from file (optional realtime pacing).
 - Service mode to have MIDI Recorder permanently on, or "Autostart" feature.
 - Notification icon.
 - Replaced Nuke with plain `dotnet` GitHub Actions; NuGet publish uses `NUGET_API_KEY` and GitHub Releases (see `.github/workflows/publish.yml`).

--- a/src/Application/MidiRecorderApplicationService.cs
+++ b/src/Application/MidiRecorderApplicationService.cs
@@ -35,7 +35,10 @@ public class MidiRecorderApplicationService<TMidiEvent>
     {
         PrintOptions(options);
 
-        (TimeSpan delayToSave, TimeSpan timeoutToSave, var pathFormatString, var midiResolution, _) = options;
+        var delayToSave = options.DelayToSave;
+        var timeoutToSave = options.TimeoutToSave;
+        var pathFormatString = options.PathFormatString;
+        var midiResolution = options.MidiResolution;
         if (!_formatTester.TestFormat(pathFormatString))
         {
             return null;
@@ -75,12 +78,24 @@ public class MidiRecorderApplicationService<TMidiEvent>
 
     private void PrintOptions(TypedRecordOptions options)
     {
-        (TimeSpan delayToSave, TimeSpan timeoutToSave, var pathFormatString, var midiResolution, _) = options;
 #pragma warning disable CA1848
         _logger.LogInformation("Working dir: {CurrentDirectory}", Environment.CurrentDirectory);
-        _logger.LogInformation("Delay to save: {DelayToSave}", delayToSave);
-        _logger.LogInformation("Timeout to save: {TimeoutToSave}", timeoutToSave);
-        _logger.LogInformation("Output Path: {PathFormatString}", pathFormatString);
-        _logger.LogInformation("MIDI resolution: {MidiResolution}", midiResolution);
+        _logger.LogInformation("Delay to save: {DelayToSave}", options.DelayToSave);
+        _logger.LogInformation("Timeout to save: {TimeoutToSave}", options.TimeoutToSave);
+        _logger.LogInformation("Output Path: {PathFormatString}", options.PathFormatString);
+        _logger.LogInformation("MIDI resolution: {MidiResolution}", options.MidiResolution);
+        if (!string.IsNullOrEmpty(options.ReplayMidiPath))
+        {
+            _logger.LogInformation(
+                "Replay from file: {ReplayPath} (realtime pacing: {ReplayRealtime})",
+                options.ReplayMidiPath,
+                options.ReplayRealtime);
+        }
+
+        if (!string.IsNullOrEmpty(options.RawCapturePath))
+        {
+            _logger.LogInformation("Raw capture file: {RawCapturePath}", options.RawCapturePath);
+        }
+#pragma warning restore CA1848
     }
 }

--- a/src/Application/TypedRecordOptions.cs
+++ b/src/Application/TypedRecordOptions.cs
@@ -5,11 +5,14 @@ public record TypedRecordOptions(
     TimeSpan TimeoutToSave,
     string PathFormatString,
     int MidiResolution,
-    IEnumerable<int> MidiInputs)
+    IEnumerable<int> MidiInputs,
+    string? RawCapturePath = null,
+    string? ReplayMidiPath = null,
+    bool ReplayRealtime = false)
 {
     public override string ToString()
     {
         return
-            $"{{ delayToSave = {DelayToSave}, timeoutToSave = {TimeoutToSave}, pathFormatString = {PathFormatString}, midiResolution = {MidiResolution} }}";
+            $"{{ delayToSave = {DelayToSave}, timeoutToSave = {TimeoutToSave}, pathFormatString = {PathFormatString}, midiResolution = {MidiResolution}, rawCapturePath = {RawCapturePath}, replayMidiPath = {ReplayMidiPath}, replayRealtime = {ReplayRealtime} }}";
     }
 }

--- a/src/CommandLine/OptionsValidator.cs
+++ b/src/CommandLine/OptionsValidator.cs
@@ -13,6 +13,27 @@ internal class OptionsValidator : IOptionsValidator
 
     public (TypedRecordOptions? typedRecordOptions, string errorMessage) Validate(RecordOptions options)
     {
+        var replayPath = string.IsNullOrWhiteSpace(options.ReplayMidi) ? null : options.ReplayMidi.Trim();
+        if (replayPath != null)
+        {
+            if (!File.Exists(replayPath))
+            {
+                return (null, $"Replay MIDI file not found: '{replayPath}'");
+            }
+
+            return (
+                new TypedRecordOptions(
+                    TimeSpan.FromMilliseconds(options.DelayToSave),
+                    TimeSpan.FromMilliseconds(30000),
+                    options.PathFormatString,
+                    options.MidiResolution,
+                    Array.Empty<int>(),
+                    string.IsNullOrWhiteSpace(options.RawCapturePath) ? null : options.RawCapturePath.Trim(),
+                    replayPath,
+                    options.ReplayRealtime),
+                "OK");
+        }
+
         var inputIds = options.MidiInputs.SelectMany(_service.GetMidiInputId).Distinct().ToArray();
         if (inputIds.Length == 0)
         {
@@ -25,6 +46,10 @@ internal class OptionsValidator : IOptionsValidator
                 TimeSpan.FromMilliseconds(30000),
                 options.PathFormatString,
                 options.MidiResolution,
-                inputIds), "OK");
+                inputIds,
+                string.IsNullOrWhiteSpace(options.RawCapturePath) ? null : options.RawCapturePath.Trim(),
+                null,
+                false),
+            "OK");
     }
 }

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -75,7 +75,7 @@ int Record(RecordOptions options)
         return 1;
     }
 
-    var sourceBuilder = new NAudioMidiSourceBuilder();
+    var sourceBuilder = new NAudioConfigurableMidiSourceBuilder();
     var saver = new NAudioMidiFileSaver();
     var analyzer = new NAudioMidiEventAnalyzer();
     var splitter = new MidiSplitter<MidiEventWithPort>();

--- a/src/CommandLine/RecordOptions.cs
+++ b/src/CommandLine/RecordOptions.cs
@@ -9,12 +9,22 @@ namespace MidiRecorder.CommandLine;
 [Verb("record", true, HelpText = "Records MIDI to files")]
 public class RecordOptions
 {
-    public RecordOptions(IEnumerable<string> midiInputs, long delayToSave, string pathFormatString, int midiResolution)
+    public RecordOptions(
+        IEnumerable<string> midiInputs,
+        long delayToSave,
+        string pathFormatString,
+        int midiResolution,
+        string? rawCapturePath,
+        string? replayMidi,
+        bool replayRealtime)
     {
         MidiInputs = midiInputs;
         PathFormatString = pathFormatString;
         DelayToSave = delayToSave;
         MidiResolution = midiResolution;
+        RawCapturePath = rawCapturePath;
+        ReplayMidi = replayMidi;
+        ReplayRealtime = replayRealtime;
     }
 
     [Option('i', "input", HelpText = "MIDI Input name or index", Default = new[] { "*" }, Separator = ',')]
@@ -33,6 +43,23 @@ public class RecordOptions
     [Option('r', "resolution", HelpText = "MIDI resolution in pulses per quarter note (PPQN)", Default = 480)]
     public int MidiResolution { get; }
 
+    [Option(
+        "raw-capture",
+        HelpText =
+            "If set, writes a single debug .mid on exit with the same event stream the tool receives (one track per input port, timing from the driver timestamps).")]
+    public string? RawCapturePath { get; }
+
+    [Option(
+        "replay",
+        HelpText =
+            "Play events from this .mid file instead of hardware input (use with captures from --raw-capture, or any Type 1 file with per-port tracks).")]
+    public string? ReplayMidi { get; }
+
+    [Option(
+        "replay-realtime",
+        HelpText = "When using --replay, pace events using tick timing from the file (default: replay as fast as possible).")]
+    public bool ReplayRealtime { get; }
+
     [Usage]
     public static IEnumerable<Example> Examples
     {
@@ -40,14 +67,17 @@ public class RecordOptions
         {
             yield return new Example(
                 "normal scenario",
-                new RecordOptions(new[] { "M1", "Triton" }, 5000, "{Now}.mid", 480));
+                new RecordOptions(new[] { "M1", "Triton" }, 5000, "{Now}.mid", 480, null, null, false));
             yield return new Example(
                 "date-based folder structure",
                 new RecordOptions(
                     new[] { "Impulse" },
                     7000,
                     @"{Now:yyyy}\{Now:MM}\{Now:dd}\{Now:yyyyMMddHHmmss}_{NumberOfNoteEvents}.mid",
-                    960));
+                    960,
+                    null,
+                    null,
+                    false));
         }
     }
 }

--- a/src/Implementation/Implementation.csproj
+++ b/src/Implementation/Implementation.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="NAudio.Midi" Version="2.3.0" />
+    <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Implementation/NAudioConfigurableMidiSourceBuilder.cs
+++ b/src/Implementation/NAudioConfigurableMidiSourceBuilder.cs
@@ -1,0 +1,18 @@
+namespace MidiRecorder.Application.Implementation;
+
+public sealed class NAudioConfigurableMidiSourceBuilder : IMidiSourceBuilder<MidiEventWithPort>
+{
+    public IMidiSource<MidiEventWithPort> Build(TypedRecordOptions typedOptions)
+    {
+        IMidiSource<MidiEventWithPort> inner = string.IsNullOrEmpty(typedOptions.ReplayMidiPath)
+            ? new NAudioMidiSource(typedOptions)
+            : new NAudioMidiReplaySource(typedOptions.ReplayMidiPath!, typedOptions.ReplayRealtime);
+
+        if (!string.IsNullOrEmpty(typedOptions.RawCapturePath))
+        {
+            inner = new RawMidiCaptureTappingSource(inner, typedOptions.RawCapturePath!, typedOptions.MidiResolution);
+        }
+
+        return inner;
+    }
+}

--- a/src/Implementation/NAudioMidiReplaySource.cs
+++ b/src/Implementation/NAudioMidiReplaySource.cs
@@ -1,0 +1,165 @@
+using System.Reactive.Subjects;
+using NAudio.Midi;
+
+namespace MidiRecorder.Application.Implementation;
+
+/// <summary>
+/// Replays MIDI file events through the same <see cref="IMidiSource{MidiEventWithPort}"/> surface as live input.
+/// </summary>
+public sealed class NAudioMidiReplaySource : IMidiSource<MidiEventWithPort>
+{
+    private readonly Subject<MidiEventWithPort> _subject = new();
+    private readonly IReadOnlyList<(TimeSpan Delay, MidiEventWithPort Event)> _steps;
+    private CancellationTokenSource? _cts;
+    private Task? _pump;
+
+    public NAudioMidiReplaySource(string midiFilePath, bool realtime)
+    {
+        _steps = BuildReplaySteps(midiFilePath, realtime);
+    }
+
+    public IObservable<MidiEventWithPort> AllEvents => _subject;
+
+    public void StartReceiving()
+    {
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+        _pump = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    foreach (var (delay, ev) in _steps)
+                    {
+                        if (delay > TimeSpan.Zero)
+                        {
+                            await Task.Delay(delay, token).ConfigureAwait(false);
+                        }
+
+                        _subject.OnNext(ev);
+                    }
+
+                    _subject.OnCompleted();
+                }
+                catch (OperationCanceledException)
+                {
+                    _subject.OnCompleted();
+                }
+            },
+            token);
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _subject.Dispose();
+    }
+
+    private static IReadOnlyList<(TimeSpan Delay, MidiEventWithPort Event)> BuildReplaySteps(
+        string midiFilePath,
+        bool realtime)
+    {
+        var midiFile = new MidiFile(midiFilePath, strictChecking: false);
+        var ppqn = midiFile.DeltaTicksPerQuarterNote;
+        var items = new List<(long Tick, int Port, MidiEvent Ev, bool IsTempo)>();
+
+        for (var trackIndex = 0; trackIndex < midiFile.Tracks; trackIndex++)
+        {
+            var trackEvents = midiFile.Events[trackIndex];
+            if (IsConductorTrack(trackEvents))
+            {
+                foreach (var midiEvent in trackEvents)
+                {
+                    if (midiEvent is TempoEvent)
+                    {
+                        items.Add((midiEvent.AbsoluteTime, 0, midiEvent, IsTempo: true));
+                    }
+                }
+
+                continue;
+            }
+
+            var port = ResolvePort(trackEvents, trackIndex);
+            foreach (var midiEvent in trackEvents)
+            {
+                if (midiEvent is TempoEvent)
+                {
+                    items.Add((midiEvent.AbsoluteTime, port, midiEvent, IsTempo: true));
+                    continue;
+                }
+
+                if (midiEvent.CommandCode == MidiCommandCode.MetaEvent)
+                {
+                    continue;
+                }
+
+                items.Add((midiEvent.AbsoluteTime, port, midiEvent, IsTempo: false));
+            }
+        }
+
+        var ordered = items
+            .OrderBy(x => x.Tick)
+            .ThenBy(x => x.IsTempo ? 0 : 1)
+            .ThenBy(x => x.Port)
+            .ToArray();
+
+        var tempoUs = NAudioRawMidiCaptureWriter.DefaultMicrosecondsPerQuarter;
+        var steps = new List<(TimeSpan Delay, MidiEventWithPort Event)>();
+        long prevTick = 0;
+
+        foreach (var (tick, port, ev, isTempo) in ordered)
+        {
+            if (isTempo && ev is TempoEvent te)
+            {
+                tempoUs = te.MicrosecondsPerQuarterNote;
+                continue;
+            }
+
+            TimeSpan delay = TimeSpan.Zero;
+            if (realtime)
+            {
+                var deltaTicks = Math.Max(0, tick - prevTick);
+                delay = TicksToDelay(deltaTicks, ppqn, tempoUs);
+                prevTick = tick;
+            }
+
+            var clone = ev.Clone();
+            clone.AbsoluteTime = tick;
+            steps.Add((delay, new MidiEventWithPort(clone, port)));
+        }
+
+        return steps;
+    }
+
+    private static bool IsConductorTrack(IList<MidiEvent> trackEvents) =>
+        trackEvents.OfType<TextEvent>()
+            .Any(
+                te => te.MetaEventType == MetaEventType.SequenceTrackName
+                      && string.Equals(te.Text, NAudioRawMidiCaptureWriter.ConductorTrackName, StringComparison.Ordinal));
+
+    private static int ResolvePort(IList<MidiEvent> trackEvents, int trackIndex)
+    {
+        foreach (var e in trackEvents.OrderBy(x => x.AbsoluteTime))
+        {
+            if (e is TextEvent { MetaEventType: MetaEventType.SequenceTrackName } te
+                && te.Text.StartsWith(NAudioRawMidiCaptureWriter.PortTrackPrefix, StringComparison.Ordinal)
+                && int.TryParse(te.Text.AsSpan(NAudioRawMidiCaptureWriter.PortTrackPrefix.Length), out var p))
+            {
+                return p;
+            }
+        }
+
+        return trackIndex;
+    }
+
+    private static TimeSpan TicksToDelay(long deltaTicks, int ppqn, int tempoUs)
+    {
+        if (deltaTicks <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var ms = deltaTicks * (tempoUs / 1000.0) / ppqn;
+        return TimeSpan.FromMilliseconds(ms);
+    }
+}

--- a/src/Implementation/NAudioMidiSourceBuilder.cs
+++ b/src/Implementation/NAudioMidiSourceBuilder.cs
@@ -1,9 +1,0 @@
-namespace MidiRecorder.Application.Implementation;
-
-public class NAudioMidiSourceBuilder : IMidiSourceBuilder<MidiEventWithPort>
-{
-    public IMidiSource<MidiEventWithPort> Build(TypedRecordOptions typedOptions)
-    {
-        return new NAudioMidiSource(typedOptions);
-    }
-}

--- a/src/Implementation/NAudioRawMidiCaptureWriter.cs
+++ b/src/Implementation/NAudioRawMidiCaptureWriter.cs
@@ -1,0 +1,81 @@
+using NAudio.Midi;
+
+namespace MidiRecorder.Application.Implementation;
+
+/// <summary>
+/// Writes a Type 1 MIDI file that preserves the merged input timeline: one conductor track (tempo map)
+/// and one track per input port. Timing is derived from <see cref="MidiEvent.AbsoluteTime"/> on captured
+/// events (NAudio driver timestamps, treated as milliseconds from session start).
+/// </summary>
+public static class NAudioRawMidiCaptureWriter
+{
+    public const int DefaultMicrosecondsPerQuarter = 500_000; // 120 BPM
+
+    public const string ConductorTrackName = "MidiRecorderConductor";
+
+    public const string PortTrackPrefix = "MidiRecorderPort:";
+
+    public static void Save(
+        IReadOnlyList<MidiEventWithPort> events,
+        string filePath,
+        int pulsesPerQuarterNote,
+        int microsecondsPerQuarter = DefaultMicrosecondsPerQuarter)
+    {
+        if (events.Count == 0)
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var t0 = events.Min(e => e.MidiEvent.AbsoluteTime);
+
+        var collection = new MidiEventCollection(1, pulsesPerQuarterNote);
+
+        var conductor = new List<MidiEvent>
+        {
+            new TempoEvent(microsecondsPerQuarter, 0),
+            new TextEvent(ConductorTrackName, MetaEventType.SequenceTrackName, 0),
+            new MetaEvent(MetaEventType.EndTrack, 0, 1)
+        };
+        collection.AddTrack(conductor);
+
+        foreach (var portGroup in events.GroupBy(e => e.Port).OrderBy(g => g.Key))
+        {
+            var ordered = portGroup.OrderBy(e => e.MidiEvent.AbsoluteTime).ToArray();
+            var track = new List<MidiEvent>
+            {
+                new TextEvent($"{PortTrackPrefix}{portGroup.Key}", MetaEventType.SequenceTrackName, 0)
+            };
+
+            foreach (var ev in ordered)
+            {
+                var msFromStart = ev.MidiEvent.AbsoluteTime - t0;
+                var ticks = MsToTicks(msFromStart, pulsesPerQuarterNote, microsecondsPerQuarter);
+                var clone = ev.MidiEvent.Clone();
+                clone.AbsoluteTime = ticks;
+                track.Add(clone);
+            }
+
+            var endTick = track[^1].AbsoluteTime + 1;
+            track.Add(new MetaEvent(MetaEventType.EndTrack, 0, endTick));
+            collection.AddTrack(track);
+        }
+
+        MidiFile.Export(filePath, collection);
+    }
+
+    private static long MsToTicks(long msFromStart, int ppqn, int microsecondsPerQuarter)
+    {
+        if (msFromStart <= 0)
+        {
+            return 0;
+        }
+
+        return msFromStart * ppqn * 1000L / microsecondsPerQuarter;
+    }
+}

--- a/src/Implementation/RawMidiCaptureTappingSource.cs
+++ b/src/Implementation/RawMidiCaptureTappingSource.cs
@@ -1,0 +1,56 @@
+using System.Reactive.Linq;
+
+namespace MidiRecorder.Application.Implementation;
+
+/// <summary>
+/// Wraps a MIDI source and, on dispose, exports everything observed on <see cref="IMidiSource{MidiEventWithPort}.AllEvents"/>
+/// as a debug MIDI file (see <see cref="NAudioRawMidiCaptureWriter"/>).
+/// </summary>
+public sealed class RawMidiCaptureTappingSource : IMidiSource<MidiEventWithPort>
+{
+    private readonly IMidiSource<MidiEventWithPort> _inner;
+    private readonly List<MidiEventWithPort> _buffer = new();
+    private readonly object _bufferLock = new();
+    private readonly string _rawCapturePath;
+    private readonly int _midiResolution;
+
+    public RawMidiCaptureTappingSource(
+        IMidiSource<MidiEventWithPort> inner,
+        string rawCapturePath,
+        int midiResolution)
+    {
+        _inner = inner;
+        _rawCapturePath = rawCapturePath;
+        _midiResolution = midiResolution;
+        AllEvents = _inner.AllEvents.Do(
+            e =>
+            {
+                lock (_bufferLock)
+                {
+                    _buffer.Add(new MidiEventWithPort(e.MidiEvent.Clone(), e.Port));
+                }
+            });
+    }
+
+    public IObservable<MidiEventWithPort> AllEvents { get; }
+
+    public void StartReceiving() => _inner.StartReceiving();
+
+    public void Dispose()
+    {
+        List<MidiEventWithPort> snapshot;
+        lock (_bufferLock)
+        {
+            snapshot = _buffer.ToList();
+        }
+
+        try
+        {
+            NAudioRawMidiCaptureWriter.Save(snapshot, _rawCapturePath, _midiResolution);
+        }
+        finally
+        {
+            _inner.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This pull request implements the debugging workflow tracked in #22.

- Adds CLI options `--raw-capture`, `--replay`, and `--replay-realtime` on `record`.
- Introduces `NAudioConfigurableMidiSourceBuilder` to compose live capture, optional raw tap-to-file, and optional replay from disk.
- Writes Type 1 debug MIDI via `NAudioRawMidiCaptureWriter` (conductor tempo track + one track per port); replay respects port metadata from capture files.

## Test plan

- [ ] `dotnet build` on solution.
- [ ] Record with hardware: `--raw-capture out.mid`, verify file on exit and normal output still works.
- [ ] Replay capture: `--replay out.mid` with and without `--replay-realtime`.
- [ ] Validation: missing `--replay` file shows clear error; replay mode does not require `-i` inputs.

Fixes #22

Made with [Cursor](https://cursor.com)