### PR TITLE
Port #17 fixes from issue17 (note off, IsNote, empty splits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Service mode to have MIDI Recorder permanently on, or "Autostart" feature.
 - Notification icon.
 
+## [1.2.1] - 2026-05-16
+
+### Fixed
+
+- Note on/off detection uses MIDI command codes so split and save work for devices that send `NoteOff` events (#17).
+- `{NumberOfNoteEvents}` in the output path format counts note events correctly.
+- Empty split windows no longer produce empty MIDI files.
+- Live `NoteOn` events no longer carry a stale note length into saved files.
+
+### Changed
+
+- Centralized NuGet package versions in `Directory.Packages.props`.
+
 ## [1.2.0] - 2026-05-15
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,23 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Ben.Demystifier" Version="0.4.1" />
+    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="fluentassertions" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
+    <PackageVersion Include="moq" Version="4.20.72" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageVersion Include="NAudio.Midi" Version="2.3.0" />
+    <PackageVersion Include="System.Reactive" Version="6.1.0" />
+  </ItemGroup>
+</Project>

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
 </Project>

--- a/src/Application/MidiRecorderApplicationService.cs
+++ b/src/Application/MidiRecorderApplicationService.cs
@@ -59,6 +59,11 @@ public class MidiRecorderApplicationService<TMidiEvent>
         void SaveMidiFile(IEnumerable<TMidiEvent> eventList)
         {
             var midiEvents = eventList as TMidiEvent[] ?? eventList.ToArray();
+            if (midiEvents.Length == 0)
+            {
+                return;
+            }
+
             var context = new MidiFileContext<TMidiEvent>(midiEvents, DateTime.Now, Guid.NewGuid(), _analyzer);
             var filePath = context.BuildFilePath(pathFormatString);
             _logger.LogInformation("Saving {EventCount} events to file {FilePath}...", midiEvents.Length, filePath);

--- a/src/Application/StringExt.cs
+++ b/src/Application/StringExt.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 
@@ -30,7 +31,12 @@ public static class StringExt
                     nameof(propertyName));
             }
 
-            throw new ArgumentException($"Property {propertyName} not found.", nameof(propertyName));
+            var availableProperties = string.Join(
+                ", ",
+                target.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(x => x.Name));
+            throw new ArgumentException(
+                $"Property {propertyName} not found. Should be one of: {availableProperties}",
+                nameof(propertyName));
         }
 
         var (format, itemNames) = TranslateToStandardFormatString(formatString);

--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -35,13 +35,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageReference Include="Ben.Demystifier" />
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -26,8 +26,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>12</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.0</Version>
-    <InformationalVersion>1.2.0</InformationalVersion>
+    <Version>1.2.1</Version>
+    <InformationalVersion>1.2.1</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Implementation/Implementation.csproj
+++ b/src/Implementation/Implementation.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio.Midi" Version="2.3.0" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="NAudio.Midi" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
 </Project>

--- a/src/Implementation/NAudioMidiEventAnalyzer.cs
+++ b/src/Implementation/NAudioMidiEventAnalyzer.cs
@@ -8,8 +8,8 @@ public class NAudioMidiEventAnalyzer : IMidiEventAnalyzer<MidiEventWithPort>
     {
         return midiEvent.MidiEvent switch
         {
-            NoteEvent { Velocity: > 0 } => 1,
-            NoteEvent { Velocity: 0 } => -1,
+            NoteEvent { CommandCode: MidiCommandCode.NoteOn } => 1,
+            NoteEvent { CommandCode: MidiCommandCode.NoteOff } => -1,
             ControlChangeEvent { Controller: MidiController.Sustain, ControllerValue: 127 } => 1,
             ControlChangeEvent { Controller: MidiController.Sustain, ControllerValue: 0 } => -1,
             _ => 0
@@ -18,6 +18,6 @@ public class NAudioMidiEventAnalyzer : IMidiEventAnalyzer<MidiEventWithPort>
 
     public bool IsNote(MidiEventWithPort midiEvent)
     {
-        return midiEvent is NoteEvent;
+        return midiEvent.MidiEvent is NoteEvent;
     }
 }

--- a/src/Implementation/NAudioMidiSource.cs
+++ b/src/Implementation/NAudioMidiSource.cs
@@ -22,6 +22,11 @@ public class NAudioMidiSource : IMidiSource<MidiEventWithPort>
                             {
                                 var eventClone = e.MidiEvent.Clone();
                                 eventClone.AbsoluteTime = e.Timestamp;
+                                if (eventClone is NoteOnEvent noteOn)
+                                {
+                                    noteOn.NoteLength = 0;
+                                }
+
                                 return new MidiEventWithPort(eventClone, inputId);
                             });
                     return (midiIn, observable);

--- a/src/UnitTests/MidiFileContextTests.cs
+++ b/src/UnitTests/MidiFileContextTests.cs
@@ -1,0 +1,33 @@
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MidiRecorder.Application;
+using MidiRecorder.Application.Implementation;
+using NAudio.Midi;
+
+namespace MidiRecorder.Tests;
+
+[TestClass]
+public class MidiFileContextTests
+{
+    [TestMethod]
+    public void BuildFilePath_AllData()
+    {
+        var analyzer = new NAudioMidiEventAnalyzer();
+        var eventList = new[]
+        {
+            new MidiEventWithPort(new NoteOnEvent(0, 1, 60, 100, 0), 0),
+            new MidiEventWithPort(new ControlChangeEvent(0, 1, MidiController.Sustain, 127), 0)
+        };
+
+        var guid = new Guid("64ea2c65-12b9-44c7-8d0b-fcf9a298f156");
+        var context = new MidiFileContext<MidiEventWithPort>(
+            eventList,
+            new DateTime(2024, 3, 17, 14, 34, 22),
+            guid,
+            analyzer);
+        var result = context.BuildFilePath(
+            "{Guid}/{NumberOfNoteEvents}/{NumberOfEvents}/{Now:yyyy}/{Now:MM}/{Now:dd_HH_mm_ss}.mid");
+        result.Should().Be("64ea2c65-12b9-44c7-8d0b-fcf9a298f156/1/2/2024/03/17_14_34_22.mid");
+    }
+}

--- a/src/UnitTests/MidiSplitterTests.cs
+++ b/src/UnitTests/MidiSplitterTests.cs
@@ -6,6 +6,8 @@ using FluentAssertions;
 using Microsoft.Reactive.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MidiRecorder.Application;
+using MidiRecorder.Application.Implementation;
+using NAudio.Midi;
 
 namespace MidiRecorder.Tests;
 
@@ -209,23 +211,112 @@ public class MidiSplitterTests
                 });
     }
 
+    [TestMethod(DisplayName = "Regression for #17")]
+    public void Split_NoteOffCommands_SingleGroup()
+    {
+        var events = new[]
+        {
+            Recorded.OnNext(100, new MidiEventWithPort(new NoteOnEvent(100, 2, 96, 64, 444), 3)),
+            Recorded.OnNext(101, new MidiEventWithPort(new NoteOnEvent(100, 1, 96, 64, 555), 3)),
+            Recorded.OnNext(105, new MidiEventWithPort(new NoteEvent(100, 2, MidiCommandCode.NoteOff, 96, 64), 3)),
+            Recorded.OnNext(106, new MidiEventWithPort(new NoteEvent(100, 1, MidiCommandCode.NoteOff, 96, 64), 3)),
+            Recorded.OnNext(110, new MidiEventWithPort(new NoteOnEvent(100, 2, 95, 64, 666), 3)),
+            Recorded.OnNext(111, new MidiEventWithPort(new NoteOnEvent(100, 1, 95, 64, 777), 3)),
+            Recorded.OnNext(112, new MidiEventWithPort(new NoteEvent(100, 2, MidiCommandCode.NoteOff, 95, 64), 3)),
+            Recorded.OnNext(113, new MidiEventWithPort(new NoteEvent(100, 1, MidiCommandCode.NoteOff, 95, 64), 3)),
+        };
+
+        var timeoutToSave = TimeSpan.FromTicks(30);
+        var delayToSave = TimeSpan.FromTicks(15);
+        var scheduler = new TestScheduler();
+        var analyzer = new NAudioMidiEventAnalyzer();
+        var sut = CreateSplit(scheduler, events, timeoutToSave, delayToSave, analyzer.NoteAndSustainPedalCount);
+
+        var result2 = PrepareResult(sut.SplitGroups, scheduler);
+        result2.Should()
+            .BeEquivalentTo(
+                new[]
+                {
+                    new[]
+                    {
+                        Recorded.Create(101, "P3 100 NoteOn Ch: 2 C8 Vel:64 Len: 444"),
+                        Recorded.Create(102, "P3 100 NoteOn Ch: 1 C8 Vel:64 Len: 555"),
+                        Recorded.Create(106, "P3 100 NoteOff Ch: 2 C8 Vel:64"),
+                        Recorded.Create(107, "P3 100 NoteOff Ch: 1 C8 Vel:64"),
+                        Recorded.Create(111, "P3 100 NoteOn Ch: 2 B7 Vel:64 Len: 666"),
+                        Recorded.Create(112, "P3 100 NoteOn Ch: 1 B7 Vel:64 Len: 777"),
+                        Recorded.Create(113, "P3 100 NoteOff Ch: 2 B7 Vel:64"),
+                        Recorded.Create(114, "P3 100 NoteOff Ch: 1 B7 Vel:64")
+                    }
+                });
+    }
+
+    [TestMethod(DisplayName = "Regression for #17")]
+    public void Split_NoteOffCommands_SplitsOnHeldTimeout()
+    {
+        var events = new[]
+        {
+            Recorded.OnNext(100, new MidiEventWithPort(new NoteOnEvent(100, 2, 96, 64, 444), 3)),
+            Recorded.OnNext(101, new MidiEventWithPort(new NoteOnEvent(100, 1, 96, 64, 555), 3)),
+            Recorded.OnNext(105, new MidiEventWithPort(new NoteEvent(100, 2, MidiCommandCode.NoteOff, 96, 64), 3)),
+            Recorded.OnNext(106, new MidiEventWithPort(new NoteEvent(100, 1, MidiCommandCode.NoteOff, 96, 64), 3)),
+            Recorded.OnNext(127, new MidiEventWithPort(new NoteOnEvent(100, 2, 95, 64, 666), 3)),
+            Recorded.OnNext(128, new MidiEventWithPort(new NoteOnEvent(100, 1, 95, 64, 777), 3)),
+            Recorded.OnNext(129, new MidiEventWithPort(new NoteEvent(100, 2, MidiCommandCode.NoteOff, 95, 64), 3)),
+            Recorded.OnNext(130, new MidiEventWithPort(new NoteEvent(100, 1, MidiCommandCode.NoteOff, 95, 64), 3)),
+        };
+
+        var timeoutToSave = TimeSpan.FromTicks(20);
+        var delayToSave = TimeSpan.FromTicks(30);
+        var scheduler = new TestScheduler();
+        var analyzer = new NAudioMidiEventAnalyzer();
+        var sut = CreateSplit(scheduler, events, timeoutToSave, delayToSave, analyzer.NoteAndSustainPedalCount);
+
+        var result2 = PrepareResult(sut.SplitGroups, scheduler);
+        result2.Should()
+            .BeEquivalentTo(
+                new[]
+                {
+                    new[]
+                    {
+                        Recorded.Create(101, "P3 100 NoteOn Ch: 2 C8 Vel:64 Len: 444"),
+                        Recorded.Create(102, "P3 100 NoteOn Ch: 1 C8 Vel:64 Len: 555"),
+                        Recorded.Create(106, "P3 100 NoteOff Ch: 2 C8 Vel:64"),
+                        Recorded.Create(107, "P3 100 NoteOff Ch: 1 C8 Vel:64"),
+                        Recorded.Create(128, "P3 100 NoteOn Ch: 2 B7 Vel:64 Len: 666"),
+                        Recorded.Create(129, "P3 100 NoteOn Ch: 1 B7 Vel:64 Len: 777"),
+                        Recorded.Create(130, "P3 100 NoteOff Ch: 2 B7 Vel:64"),
+                        Recorded.Create(131, "P3 100 NoteOff Ch: 1 B7 Vel:64")
+                    }
+                });
+    }
+
     private static MidiSplit<string> CreateSplit(
         TestScheduler scheduler,
         Recorded<Notification<string>>[] events,
         TimeSpan timeoutToSave,
         TimeSpan delayToSave)
     {
-        var allEvents = scheduler.CreateColdObservable(events);
-        var sut = new MidiSplitter<string>(scheduler);
-        var split = sut.Split(allEvents, NoteAndSustainPedalCount, timeoutToSave, delayToSave);
-        return split;
+        return CreateSplit(scheduler, events, timeoutToSave, delayToSave, NoteAndSustainPedalCount);
     }
 
-    private static Recorded<string>[][] PrepareResult(IObservable<IObservable<string>> result, TestScheduler scheduler)
+    private static MidiSplit<T> CreateSplit<T>(
+        TestScheduler scheduler,
+        Recorded<Notification<T>>[] events,
+        TimeSpan timeoutToSave,
+        TimeSpan delayToSave,
+        Func<T, int> noteAndSustainPedalCount)
+    {
+        var allEvents = scheduler.CreateColdObservable(events);
+        var sut = new MidiSplitter<T>(scheduler);
+        return sut.Split(allEvents, noteAndSustainPedalCount, timeoutToSave, delayToSave);
+    }
+
+    private static Recorded<string>[][] PrepareResult<T>(IObservable<IObservable<T>> result, TestScheduler scheduler)
     {
         return result.SelectMany((observable, index) => observable.Select(x => (index, x)))
             .WaitAndGetRecorded(scheduler)
-            .GroupBy(x => x.Value.index, x => Recorded.Create(x.Time, x.Value.x))
+            .GroupBy(x => x.Value.index, x => Recorded.Create(x.Time, x.Value.x?.ToString() ?? ""))
             .Select(x => x.ToArray())
             .ToArray();
     }

--- a/src/UnitTests/NAudioMidiEventAnalyzerTests.cs
+++ b/src/UnitTests/NAudioMidiEventAnalyzerTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MidiRecorder.Application.Implementation;
+using NAudio.Midi;
+
+namespace MidiRecorder.Tests;
+
+[TestClass]
+public class NAudioMidiEventAnalyzerTests
+{
+    private readonly NAudioMidiEventAnalyzer _analyzer = new();
+
+    [TestMethod(DisplayName = "Regression for #17")]
+    public void NoteAndSustainPedalCount_NoteOffCommand_DecrementsHeldCount()
+    {
+        var noteOff = new MidiEventWithPort(
+            new NoteEvent(0, 1, MidiCommandCode.NoteOff, 60, 0),
+            0);
+        _analyzer.NoteAndSustainPedalCount(noteOff).Should().Be(-1);
+    }
+
+    [TestMethod(DisplayName = "Regression for #17")]
+    public void IsNote_WrappedNoteEvent_ReturnsTrue()
+    {
+        var noteOn = new MidiEventWithPort(new NoteOnEvent(0, 1, 60, 100, 0), 0);
+        _analyzer.IsNote(noteOn).Should().BeTrue();
+    }
+}

--- a/src/UnitTests/TrackBuilderTests.cs
+++ b/src/UnitTests/TrackBuilderTests.cs
@@ -1,0 +1,16 @@
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MidiRecorder.Application.Implementation;
+
+namespace MidiRecorder.Tests;
+
+[TestClass]
+public class TrackBuilderTests
+{
+    [TestMethod(DisplayName = "Regression for #17")]
+    public void BuildTracks_EmptyInput_ReturnsEmpty()
+    {
+        new NAudioMidiTrackBuilder().BuildTracks(Array.Empty<MidiEventWithPort>()).Should().BeEmpty();
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -15,13 +15,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="fluentassertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.1.0" />
-    <PackageReference Include="moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="fluentassertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Reactive.Testing" />
+    <PackageReference Include="moq" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Detect note on/off via `MidiCommandCode` instead of velocity, so devices that send real `NoteOff` events split and save correctly (#17).
- Fix `IsNote` on `MidiEventWithPort` so `{NumberOfNoteEvents}` path placeholders work.
- Clear `NoteLength` on cloned live `NoteOn` events before recording.
- Skip empty Rx split windows when saving MIDI files.
- Improve `StringExt` errors when a path format property name is wrong.
- Add regression tests (analyzer, splitter, track builder, file context).

## Test plan

- [x] `dotnet test src/UnitTests/UnitTests.csproj` (21 passed)
- [ ] Manual: record from a keyboard that sends `NoteOff` (not velocity-0 `NoteOn`) and confirm splits/saves behave as expected
- [ ] Manual: verify `-f` path with `{NumberOfNoteEvents}` reflects actual note count

Made with [Cursor](https://cursor.com)